### PR TITLE
change poodle link reference

### DIFF
--- a/Resources/views/Incident/Report/Markdown/poodle.md
+++ b/Resources/views/Incident/Report/Markdown/poodle.md
@@ -16,7 +16,7 @@ Acceda a la siguiente página para verificar que los servicios que usted
 provee en el host son vulnerables a POODLE:
 
 ### [destacated]
-* [https://www.poodlescan.com/](https://www.poodlescan.com/)
+* [http://poodletest.ntt-security.com/](http://poodletest.ntt-security.com/)
 ### [/destacated]
 ### [/verification_content]
 

--- a/Resources/views/Incident/Report/Twig/poodleReport.html.twig
+++ b/Resources/views/Incident/Report/Twig/poodleReport.html.twig
@@ -1,8 +1,8 @@
-{# 
+{#
  This file is part of the Ngen - CSIRT Incident Report System.
- 
+
  (c) CERT UNLP <support@cert.unlp.edu.ar>
- 
+
  This source file is subject to the GPL v3.0 license that is bundled
  with this source code in the file LICENSE.
 #}
@@ -38,7 +38,7 @@ provee en el host son vulnerables a POODLE:
 <div class = "destacated">
 
 <ul>
-<li><a href="https://www.poodlescan.com/">https://www.poodlescan.com/</a></li>
+<li><a href="http://poodletest.ntt-security.com/">http://poodletest.ntt-security.com/</a></li>
 </ul>
 
 </div>


### PR DESCRIPTION
Link to https://www.poodlescan.com/ does not exists any more so may be changed to http://poodletest.ntt-security.com/